### PR TITLE
[Forwardport] #12820 - Wrong annotation in _toOptionArray - magento/framework/Data/…

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -630,7 +630,7 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
     /**
      * Overridden to use _idFieldName by default.
      *
-     * @param null $valueField
+     * @param string|null $valueField
      * @param string $labelField
      * @param array $additional
      * @return array


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15336
Set correct annotation in _toOptionArray - magento/framework/Data/Collection/AbstractDb.php

### Description
Set correct annotation in _toOptionArray - magento/framework/Data/Collection/AbstractDb.php

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<12820>: Wrong annotation in _toOptionArray - magento/framework/Data/Collection/AbstractDb.php

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Please check request parameter in _toOptionArray - magento/framework/Data/Collection/AbstractDb.php

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
