### PR TITLE
[Backport] Wrong annotation in _toOptionArray : lib\internal\Magento\Framework\D…

### DIFF
--- a/app/code/Magento/Braintree/i18n/en_US.csv
+++ b/app/code/Magento/Braintree/i18n/en_US.csv
@@ -166,3 +166,4 @@ Debug,Debug
 "apple_pay_card","Apple pay card"
 "android_pay_card","Android pay card"
 "Accept credit/debit cards and PayPal in your Magento store.<br/>No setup or monthly fees and your customers never leave your store to complete the purchase.","Accept credit/debit cards and PayPal in your Magento store.<br/>No setup or monthly fees and your customers never leave your store to complete the purchase."
+"Save for later use.","Save for later use."

--- a/app/code/Magento/Braintree/view/adminhtml/templates/form/cc.phtml
+++ b/app/code/Magento/Braintree/view/adminhtml/templates/form/cc.phtml
@@ -84,7 +84,7 @@ $ccType = $block->getInfoData('cc_type');
                    name="payment[is_active_payment_token_enabler]"
                    class="admin__control-checkbox"/>
             <label class="label" for="<?php /* @noEscape */ echo $code; ?>_vault">
-                <span><?php echo $block->escapeHtml('Save for later use.'); ?></span>
+                <span><?php echo $block->escapeHtml(__('Save for later use.')); ?></span>
             </label>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Catalog/Setup/InstallSchema.php
+++ b/app/code/Magento/Catalog/Setup/InstallSchema.php
@@ -674,7 +674,7 @@ class InstallSchema implements InstallSchemaInterface
                 \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
                 null,
                 ['unsigned' => true, 'nullable' => false, 'default' => '0'],
-                'Attriute Set ID'
+                'Attribute Set ID'
             )
             ->addColumn(
                 'parent_id',

--- a/app/code/Magento/Catalog/view/base/web/js/price-utils.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-utils.js
@@ -70,7 +70,7 @@ define([
         am = Number(Math.round(Math.abs(amount - i) + 'e+' + precision) + ('e-' + precision));
         r = (j ? i.substr(0, j) + groupSymbol : '') +
             i.substr(j).replace(re, '$1' + groupSymbol) +
-            (precision ? decimalSymbol + am.toFixed(2).replace(/-/, 0).slice(2) : '');
+            (precision ? decimalSymbol + am.toFixed(precision).replace(/-/, 0).slice(2) : '');
 
         return pattern.replace('%s', r).replace(/^\s\s*/, '').replace(/\s\s*$/, '');
     }

--- a/app/code/Magento/Checkout/etc/webapi.xml
+++ b/app/code/Magento/Checkout/etc/webapi.xml
@@ -104,7 +104,7 @@
             <resource ref="anonymous" />
         </resources>
     </route>
-    <!-- Managing My shipping information -->
+    <!-- Managing My payment information -->
     <route url="/V1/carts/mine/set-payment-information" method="POST">
         <service class="Magento\Checkout\Api\PaymentInformationManagementInterface" method="savePaymentInformation"/>
         <resources>

--- a/app/code/Magento/Paypal/i18n/en_US.csv
+++ b/app/code/Magento/Paypal/i18n/en_US.csv
@@ -680,3 +680,4 @@ User,User
 "payflowpro","Payflow Pro"
 "Payments Pro","Payments Pro"
 "Website Payments Pro","Website Payments Pro"
+"Save for later use.","Save for later use."

--- a/app/code/Magento/Paypal/view/adminhtml/templates/transparent/form.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/transparent/form.phtml
@@ -135,7 +135,7 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                    name="payment[is_active_payment_token_enabler]"
                    class="admin__control-checkbox"/>
             <label class="label" for="<?php /* @noEscape */ echo $code; ?>_vault">
-                <span><?php echo $block->escapeHtml('Save for later use.'); ?></span>
+                <span><?php echo $block->escapeHtml(__('Save for later use.')); ?></span>
             </label>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Review/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Review/etc/adminhtml/menu.xml
@@ -9,7 +9,7 @@
     <menu>
         <add id="Magento_Review::catalog_reviews_ratings_ratings" title="Rating" translate="title" module="Magento_Review" sortOrder="60" parent="Magento_Backend::stores_attributes" action="review/rating/" resource="Magento_Review::ratings"/>
         <add id="Magento_Review::catalog_reviews_ratings_reviews_all" title="Reviews" translate="title" module="Magento_Review" parent="Magento_Backend::marketing_user_content" sortOrder="10" action="review/product/index" resource="Magento_Review::reviews_all"/>
-    <add id="Magento_Review::report_review" title="Reviews" translate="title" module="Magento_Reports" sortOrder="20" parent="Magento_Reports::report" resource="Magento_Reports::review"/>
+        <add id="Magento_Review::report_review" title="Reviews" translate="title" module="Magento_Reports" sortOrder="20" parent="Magento_Reports::report" resource="Magento_Reports::review"/>
         <add id="Magento_Review::report_review_customer" title="By Customers" translate="title" sortOrder="10" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/customer" resource="Magento_Reports::review_customer"/>
         <add id="Magento_Review::report_review_product" title="By Products" translate="title" sortOrder="20" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/product" resource="Magento_Reports::review_product"/>
     </menu>

--- a/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
+++ b/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
@@ -188,8 +188,8 @@ class SearchResultProcessor extends AbstractDataObject implements SearchResultPr
     }
 
     /**
-     * @param string $labelField
-     * @param string $labelField
+     * @param string|null $valueField
+     * @param string|null $labelField
      * @param array $additional
      * @return array
      */

--- a/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
+++ b/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
@@ -188,8 +188,8 @@ class SearchResultProcessor extends AbstractDataObject implements SearchResultPr
     }
 
     /**
-     * @param null $valueField
-     * @param null $labelField
+     * @param string $labelField
+     * @param string $labelField
      * @param array $additional
      * @return array
      */

--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -72,6 +72,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'mk_MK', /*Macedonian (Macedonia)*/
         'mn_Cyrl_MN', /*Mongolian (Mongolia)*/
         'ms_Latn_MY', /*Malaysian (Malaysia)*/
+        'ms_MY', /*Malaysian (Malaysia)*/
         'nl_BE', /*Dutch (Belgium)*/
         'nl_NL', /*Dutch (Netherlands)*/
         'nb_NO', /*Norwegian BokmГ_l (Norway)*/

--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -98,6 +98,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'lo_LA', /*Laotian*/
         'es_VE', /*Spanish (Venezuela)*/
         'en_IE', /*English (Ireland)*/
+        'es_BO', /*Spanish (Bolivia)*/
     ];
 
     /**

--- a/lib/web/css/docs/source/docs.less
+++ b/lib/web/css/docs/source/docs.less
@@ -21,7 +21,6 @@
 @import '_icons.less';
 @import '_loaders.less';
 @import '_messages.less';
-//@import 'navigation.less';
 @import '_layout.less';
 @import '_pages.less';
 @import '_popups.less';


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15892
### Original Pull Request 
Set correct annotation in _toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php
### Description
Set correct annotation in _toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<12820>: Wrong annotation in _toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Please check request parameter in _toOptionArray - magento/framework/Data/Collection/AbstractDb.php

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
