### PR TITLE
[Backport] Add indexes to timestamp field in oauth_nonce

### DIFF
--- a/app/code/Magento/Integration/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Integration/Setup/UpgradeSchema.php
@@ -71,6 +71,16 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $setup->getConnection()->createTable($table);
         }
 
+        if (version_compare($context->getVersion(), '2.2.1', '<')) {
+            $connection = $setup->getConnection();
+
+            $connection->addIndex(
+                $setup->getTable('oauth_nonce'),
+                $setup->getIdxName('oauth_nonce', ['timestamp']),
+                ['timestamp']
+            );
+        }
+
         $setup->endSetup();
     }
 }

--- a/app/code/Magento/Integration/etc/module.xml
+++ b/app/code/Magento/Integration/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Integration" setup_version="2.2.0">
+    <module name="Magento_Integration" setup_version="2.2.1">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_User"/>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13328
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Inclusion of indexes into timestamp field in order to avoid deadlocks while on erasing old records.

### Fixed Issues (if relevant)
1. magento/magento2#10346: Deadlock occurs using REST API & OAuth 1.0a under high concurrency

### Manual testing scenarios
1. Pull the code and run `php bin/magento setup:upgrade`
2. Create thousands of OAuth 1.0a requests to REST API (eg concurrency of 5 / sec)
3. Requests should complete successfully

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
